### PR TITLE
Update README for Github Packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ sys     0m0.006s
 
 Did you want to run this in a Docker container?
 
-This is currently published on Docker Hub and you can `docker run -p 5000:5000 drincruz/gohang:0.2.0`.
+This is currently published on Github Packages and you can `docker run -p 5000:5000 ghcr.io/drincruz/gohang:main`.
 
 If you wanted to build locally, simply run `docker-compose build` and then `docker-compose up`.
 


### PR DESCRIPTION
Github Actions now publishes directly to Github Packages, so why not!