### PR TITLE
Remove the cron from the Docker Publish Action

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,8 +6,6 @@ name: Docker
 # documentation.
 
 on:
-  schedule:
-    - cron: '25 4 * * *'
   push:
     branches: [ main ]
     # Publish semver tags as releases.


### PR DESCRIPTION
There is no need to have this run nightly. We can just publish images on commits.