### PR TITLE
Support a different port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # gohang
+
 A simple HTTP server for testing
 
 ## Build from source
@@ -97,4 +98,19 @@ $ docker-compose up
 Recreating gohang_web_1 ... done
 Attaching to gohang_web_1
 web_1  | 2020/10/04 21:16:09 [INFO] Now listening on :5000
+```
+
+## Running Tests
+
+To run tests, you can just run `go test ./...`
+
+## Optional Port Setting
+
+In the case where you want to have the server run on a different port, you can set the environment variable, `GOHANG_PORT`.
+
+For example, running the following will have the server listen on port 5555.
+
+```bash
+$ GOHANG_PORT=5555 ./gohang
+2023/01/07 21:18:33 [INFO] Now listening on :5555
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module gohang
 
 go 1.18
+
+require github.com/stretchr/testify v1.8.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/gohang.go
+++ b/gohang.go
@@ -1,12 +1,20 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"time"
 )
 
-const DEFAULT_PORT string = ":5000"
+func getDefaultPort() string {
+	port, exists := os.LookupEnv("GOHANG_PORT")
+	if exists {
+		return fmt.Sprintf(":%s", port)
+	}
+	return ":5000"
+}
 
 func writeJsonResponseHeader(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json")
@@ -42,6 +50,8 @@ func main() {
 	mux.HandleFunc("/404", NotFound)
 	mux.HandleFunc("/slow", SlowResponse)
 
-	log.Printf("[INFO] Now listening on %s", DEFAULT_PORT)
-	http.ListenAndServe(DEFAULT_PORT, mux)
+	port := getDefaultPort()
+
+	log.Printf("[INFO] Now listening on %s", port)
+	http.ListenAndServe(port, mux)
 }

--- a/gohang_test.go
+++ b/gohang_test.go
@@ -1,76 +1,84 @@
 package main
 
 import (
-    "net/http"
-    "net/http/httptest"
-    "testing"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
 )
 
 func TestOkTwoHundredHandler(t *testing.T) {
-    req, err := http.NewRequest("GET", "/", nil)
-    if err != nil {
-        t.Fatal(err)
-    }
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-    rr := httptest.NewRecorder()
-    handler := http.HandlerFunc(OkTwoHundred)
-    handler.ServeHTTP(rr, req)
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(OkTwoHundred)
+	handler.ServeHTTP(rr, req)
 
-    // Check the status code
-    if status := rr.Code; status != http.StatusOK {
-        t.Errorf("handler returned wrong status code: got %v want %v",
-            status, http.StatusOK)
-    }
+	// Check the status code
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
 
-    expected := `{ "data": "200 OK" }`
-    if rr.Body.String() != expected {
-        t.Errorf("handler returned unexpected body: got %v want %v",
-            rr.Body.String(), expected)
-    }
+	expected := `{ "data": "200 OK" }`
+	if rr.Body.String() != expected {
+		t.Errorf("handler returned unexpected body: got %v want %v",
+			rr.Body.String(), expected)
+	}
 }
 
 func TestFiveHundredHandler(t *testing.T) {
-    req, err := http.NewRequest("GET", "/500", nil)
-    if err != nil {
-        t.Fatal(err)
-    }
+	req, err := http.NewRequest("GET", "/500", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-    rr := httptest.NewRecorder()
-    handler := http.HandlerFunc(FiveHundred)
-    handler.ServeHTTP(rr, req)
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(FiveHundred)
+	handler.ServeHTTP(rr, req)
 
-    // Check the status code
-    if status := rr.Code; status != http.StatusInternalServerError{
-        t.Errorf("handler returned wrong status code: got %v want %v",
-            status, http.StatusInternalServerError)
-    }
+	// Check the status code
+	if status := rr.Code; status != http.StatusInternalServerError {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusInternalServerError)
+	}
 
-    expected := `{ "data": "500 Internal Server Error" }`
-    if rr.Body.String() != expected {
-        t.Errorf("handler returned unexpected body: got %v want %v",
-            rr.Body.String(), expected)
-    }
+	expected := `{ "data": "500 Internal Server Error" }`
+	if rr.Body.String() != expected {
+		t.Errorf("handler returned unexpected body: got %v want %v",
+			rr.Body.String(), expected)
+	}
 }
 
 func TestNotFoundHandler(t *testing.T) {
-    req, err := http.NewRequest("GET", "/404", nil)
-    if err != nil {
-        t.Fatal(err)
-    }
+	req, err := http.NewRequest("GET", "/404", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-    rr := httptest.NewRecorder()
-    handler := http.HandlerFunc(NotFound)
-    handler.ServeHTTP(rr, req)
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(NotFound)
+	handler.ServeHTTP(rr, req)
 
-    // Check the status code
-    if status := rr.Code; status != http.StatusNotFound {
-        t.Errorf("handler returned wrong status code: got %v want %v",
-            status, http.StatusNotFound)
-    }
+	// Check the status code
+	if status := rr.Code; status != http.StatusNotFound {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusNotFound)
+	}
 
-    expected := `{ "data": "404 Not Found" }`
-    if rr.Body.String() != expected {
-        t.Errorf("handler returned unexpected body: got %v want %v",
-            rr.Body.String(), expected)
-    }
+	expected := `{ "data": "404 Not Found" }`
+	if rr.Body.String() != expected {
+		t.Errorf("handler returned unexpected body: got %v want %v",
+			rr.Body.String(), expected)
+	}
+}
+
+func TestDefaultPort(t *testing.T) {
+	want := ":5000"
+	defaultPort := getDefaultPort()
+
+	assert.Equal(t, want, defaultPort, "Default port should be 5000")
 }


### PR DESCRIPTION
If we set an optional environment variable, `GOHANG_PORT` we can listen on that specific port instead of the default 5000.